### PR TITLE
added missing RedCloth dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source :rubygems
 
 gem "jekyll"
 gem "ruby-xslt"
+gem "RedCloth"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    RedCloth (4.2.9)
     albino (1.3.3)
       posix-spawn (>= 0.3.6)
     classifier (1.3.3)
@@ -26,5 +27,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  RedCloth
   jekyll
   ruby-xslt


### PR DESCRIPTION
Jekyll complained:

```
$ bundle exec jekyll
Configuration from .../roca/_config.yml
Building site: .../roca -> .../roca/_site
You are missing a library required for Textile. Please run:
  $ [sudo] gem install RedCloth
```
