### PR TITLE
Promote htmx as library that embodies ROCA principles

### DIFF
--- a/libraries.md
+++ b/libraries.md
@@ -22,6 +22,9 @@ difficult to fully capture a continuously evolving ecosystem.
 Further [suggestions](discussion.html) and
 [contributions](https://github.com/innoq/ROCA) are welcome!
 
+* ### [htmx](https://htmx.org/) high power tools for HTML
+  htmx allows you to access AJAX, CSS Transitions, WebSockets and Server Sent Events directly in HTML, using attributes, so you can build modern user interfaces with the simplicity and power of hypertext.
+
 * ### [Hotwire](https://hotwire.dev/) HTML Over The Wire
   an outstanding group of libraries. Mostly POSH with a little unobtrusive JavaScript for progressive enhancement. From the Basecamp team.
 


### PR DESCRIPTION
With pjax being [largely unmaintained](https://github.com/defunkt/jquery-pjax#status-of-this-project), [htmx](https://htmx.org/) is probably the next library the qualifies as _a near-perfect embodiment of ROCA principles_ and should probably be promoted among [ROCA libraries](https://roca-style.org/libraries.html).